### PR TITLE
Persist frontend messages

### DIFF
--- a/talemate_frontend/src/components/SceneMessages.vue
+++ b/talemate_frontend/src/components/SceneMessages.vue
@@ -83,6 +83,7 @@ import StatusMessage from './StatusMessage.vue';
 import RequestInput from './RequestInput.vue';
 import PlayerChoiceMessage from './PlayerChoiceMessage.vue';
 import ContextInvestigationMessage from './ContextInvestigationMessage.vue';
+import messageStore from '../store/messageStore';
 
 const MESSAGE_FLAGS = {
     NONE: 0,
@@ -115,7 +116,6 @@ export default {
     },
     data() {
         return {
-            messages: [],
             defaultColors: {
                 "narrator": "#B39DDB",
                 "character": "#FFFFFF",
@@ -126,6 +126,14 @@ export default {
         }
     },
     computed: {
+        messages: {
+            get() {
+                return messageStore.messages;
+            },
+            set(val) {
+                messageStore.messages = val;
+            }
+        },
         editorRevisionsEnabled() {
             return this.agentStatus && this.agentStatus.editor && this.agentStatus.editor.actions && this.agentStatus.editor.actions["revision"] && this.agentStatus.editor.actions["revision"].enabled;
         }

--- a/talemate_frontend/src/components/TalemateApp.vue
+++ b/talemate_frontend/src/components/TalemateApp.vue
@@ -297,6 +297,7 @@ import DirectorConsole from './DirectorConsole.vue';
 import DirectorConsoleWidget from './DirectorConsoleWidget.vue';
 // import debounce
 import { debounce } from 'lodash';
+import { hydrateMessages } from '../store/messageStore';
 
 export default {
   components: {
@@ -515,6 +516,7 @@ export default {
     }
   },
   mounted() {
+    hydrateMessages();
     this.connect();
     this.favicon = document.querySelector('link[rel="icon"]');
   },

--- a/talemate_frontend/src/store/messageStore.js
+++ b/talemate_frontend/src/store/messageStore.js
@@ -1,0 +1,27 @@
+import { reactive, watch } from 'vue'
+
+export const messageStore = reactive({
+  messages: []
+})
+
+export function hydrateMessages() {
+  const saved = localStorage.getItem('talemate_messages')
+  if (saved) {
+    try {
+      messageStore.messages = JSON.parse(saved)
+    } catch (e) {
+      console.error('Failed to parse saved messages from localStorage', e)
+      messageStore.messages = []
+    }
+  }
+}
+
+watch(
+  () => messageStore.messages,
+  (msgs) => {
+    localStorage.setItem('talemate_messages', JSON.stringify(msgs))
+  },
+  { deep: true }
+)
+
+export default messageStore


### PR DESCRIPTION
## Summary
- add a small message store using Vue reactivity
- load saved messages from `localStorage` when the app mounts
- persist messages to `localStorage` whenever they update
- use the message store in `SceneMessages`